### PR TITLE
WIP: use associated type for WIDTH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-interface"
 description = "Traits for interfaces used to drive displays"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
 repository = "https://github.com/therealprof/display-interface"
 documentation = "https://docs.rs/display-interface"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ members = [
     "parallel-gpio",
     "spi",
 ]
+
+[patch.crates-io]
+display-interface = { version = "0.3", path = "." }
+

--- a/i2c/Cargo.toml
+++ b/i2c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-interface-i2c"
 description = "Generic I2C implementation for display interfaces"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
 repository = "https://github.com/therealprof/display-interface"
 documentation = "https://docs.rs/display-interface-i2c"
@@ -19,4 +19,4 @@ all-features = true
 
 [dependencies]
 embedded-hal = "0.2.3"
-display-interface = "0.2"
+display-interface = "0.3"

--- a/i2c/src/lib.rs
+++ b/i2c/src/lib.rs
@@ -33,13 +33,12 @@ where
     fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
         // Copy over given commands to new aray to prefix with command identifier
         match cmds {
-            DataFormat::U8(iter) => {
+            DataFormat::U8(slice) => {
                 let mut writebuf: [u8; 8] = [0; 8];
-                let sliced = iter.as_slice();
-                writebuf[1..=sliced.len()].copy_from_slice(&sliced[0..sliced.len()]);
+                writebuf[1..=slice.len()].copy_from_slice(&slice[0..slice.len()]);
 
                 self.i2c
-                    .write(self.addr, &writebuf[..=sliced.len()])
+                    .write(self.addr, &writebuf[..=slice.len()])
                     .map_err(|_| DisplayError::BusWriteError)
             }
             _ => Err(DisplayError::BusWriteError), // TODO: support u16
@@ -48,9 +47,8 @@ where
 
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
         match buf {
-            DataFormat::U8(iter) => {
+            DataFormat::U8(slice) => {
                 // No-op if the data buffer is empty
-                let slice = iter.as_slice();
                 if slice.is_empty() {
                     return Ok(());
                 }

--- a/i2c/src/lib.rs
+++ b/i2c/src/lib.rs
@@ -26,10 +26,12 @@ where
     }
 }
 
-impl<I2C> WriteOnlyDataCommand<u8> for I2CInterface<I2C>
+impl<I2C> WriteOnlyDataCommand for I2CInterface<I2C>
 where
     I2C: hal::blocking::i2c::Write,
 {
+    type Width = u8;
+
     fn send_commands(&mut self, cmds: &[u8]) -> Result<(), DisplayError> {
         // Copy over given commands to new aray to prefix with command identifier
         let mut writebuf: [u8; 8] = [0; 8];

--- a/i2c/src/lib.rs
+++ b/i2c/src/lib.rs
@@ -3,7 +3,7 @@
 //! Generic I2C interface for display drivers
 use embedded_hal as hal;
 
-use display_interface::{DisplayError, WriteOnlyDataCommand};
+use display_interface::{DisplayError, WriteOnlyDataCommand, DataFormat};
 
 /// I2C communication interface
 pub struct I2CInterface<I2C> {
@@ -30,38 +30,49 @@ impl<I2C> WriteOnlyDataCommand for I2CInterface<I2C>
 where
     I2C: hal::blocking::i2c::Write,
 {
-    type Width = u8;
-
-    fn send_commands(&mut self, cmds: &[u8]) -> Result<(), DisplayError> {
+    fn send_commands<'a>(&mut self, cmds: DataFormat<'a>) -> Result<(), DisplayError> {
         // Copy over given commands to new aray to prefix with command identifier
-        let mut writebuf: [u8; 8] = [0; 8];
-        writebuf[1..=cmds.len()].copy_from_slice(&cmds[0..cmds.len()]);
-
-        self.i2c
-            .write(self.addr, &writebuf[..=cmds.len()])
-            .map_err(|_| DisplayError::BusWriteError)
-    }
-
-    fn send_data(&mut self, buf: &[u8]) -> Result<(), DisplayError> {
-        // No-op if the data buffer is empty
-        if buf.is_empty() {
-            return Ok(());
+        match cmds {
+            DataFormat::U8(iter) => {
+                let mut writebuf: [u8; 8] = [0; 8];
+                let sliced = iter.as_slice();
+                writebuf[1..=sliced.len()].copy_from_slice(&sliced[0..sliced.len()]);
+        
+                self.i2c
+                    .write(self.addr, &writebuf[..=sliced.len()])
+                    .map_err(|_| DisplayError::BusWriteError)
+            },
+            _ => Err(DisplayError::BusWriteError), // TODO: support u16
         }
 
-        let mut writebuf: [u8; 17] = [0; 17];
+    }
 
-        // Data mode
-        writebuf[0] = self.data_byte;
+    fn send_data<'a>(&mut self, buf: DataFormat<'a>) -> Result<(), DisplayError> {
+        match buf {
+            DataFormat::U8(iter) => {
+                // No-op if the data buffer is empty
+                let slice = iter.as_slice();
+                if slice.is_empty() {
+                    return Ok(());
+                }
 
-        buf.chunks(16)
-            .try_for_each(|c| {
-                let chunk_len = c.len();
+                let mut writebuf: [u8; 17] = [0; 17];
 
-                // Copy over all data from buffer, leaving the data command byte intact
-                writebuf[1..=chunk_len].copy_from_slice(c);
+                // Data mode
+                writebuf[0] = self.data_byte;
 
-                self.i2c.write(self.addr, &writebuf[0..=chunk_len])
-            })
-            .map_err(|_| DisplayError::BusWriteError)
+                slice.chunks(16)
+                    .try_for_each(|c| {
+                        let chunk_len = c.len();
+
+                        // Copy over all data from buffer, leaving the data command byte intact
+                        writebuf[1..=chunk_len].copy_from_slice(c);
+
+                        self.i2c.write(self.addr, &writebuf[0..=chunk_len])
+                    })
+                    .map_err(|_| DisplayError::BusWriteError)
+            },
+            _ => Err(DisplayError::BusWriteError), // TODO: support u16
+        }
     }
 }

--- a/i2c/src/lib.rs
+++ b/i2c/src/lib.rs
@@ -41,7 +41,7 @@ where
                     .write(self.addr, &writebuf[..=slice.len()])
                     .map_err(|_| DisplayError::BusWriteError)
             }
-            _ => Err(DisplayError::BusWriteError), // TODO: support u16
+            _ => Err(DisplayError::InvalidFormatError), // TODO: support u16
         }
     }
 
@@ -70,7 +70,7 @@ where
                     })
                     .map_err(|_| DisplayError::BusWriteError)
             }
-            _ => Err(DisplayError::BusWriteError), // TODO: support u16
+            _ => Err(DisplayError::InvalidFormatError), // TODO: support u16
         }
     }
 }

--- a/parallel-gpio/Cargo.toml
+++ b/parallel-gpio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-interface-parallel-gpio"
 description = "Generic parallel GPIO interface for display interfaces"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
 repository = "https://github.com/therealprof/display-interface"
 documentation = "https://docs.rs/display-interface-parallel-gpio"
@@ -19,4 +19,6 @@ all-features = true
 
 [dependencies]
 embedded-hal = "0.2.3"
-display-interface = "0.2"
+display-interface = "0.3"
+byte-slice-cast = { version = "0.3.5", default-features = false }
+

--- a/spi/Cargo.toml
+++ b/spi/Cargo.toml
@@ -20,3 +20,4 @@ all-features = true
 [dependencies]
 embedded-hal = "0.2.3"
 display-interface = "0.3"
+byte-slice-cast = { version = "0.3.5", default-features = false }

--- a/spi/Cargo.toml
+++ b/spi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-interface-spi"
 description = "Generic SPI implementation for display interfaces"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
 repository = "https://github.com/therealprof/display-interface"
 documentation = "https://docs.rs/display-interface-spi"
@@ -19,4 +19,4 @@ all-features = true
 
 [dependencies]
 embedded-hal = "0.2.3"
-display-interface = "0.2"
+display-interface = "0.3"

--- a/spi/src/lib.rs
+++ b/spi/src/lib.rs
@@ -47,7 +47,7 @@ where
                 self.cs.set_high().ok();
                 err
             }
-            _ => Err(DisplayError::BusWriteError),
+            _ => Err(DisplayError::InvalidFormatError), // TODO: support u16
         }
     }
 
@@ -64,7 +64,7 @@ where
                 self.cs.set_high().ok();
                 err
             }
-            _ => Err(DisplayError::BusWriteError),
+            _ => Err(DisplayError::InvalidFormatError), // TODO: support u16
         }
     }
 }
@@ -102,7 +102,7 @@ where
                     .write(slice)
                     .map_err(|_| DisplayError::BusWriteError)
             }
-            _ => Err(DisplayError::BusWriteError),
+            _ => Err(DisplayError::InvalidFormatError), // TODO: support u16
         }
     }
 
@@ -115,7 +115,7 @@ where
                     .write(slice)
                     .map_err(|_| DisplayError::BusWriteError)
             }
-            _ => Err(DisplayError::BusWriteError),
+            _ => Err(DisplayError::InvalidFormatError), // TODO: support u16
         }
     }
 }

--- a/spi/src/lib.rs
+++ b/spi/src/lib.rs
@@ -36,13 +36,13 @@ where
 {
     fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
         match cmds {
-            DataFormat::U8(iter) => {
+            DataFormat::U8(slice) => {
                 self.cs.set_low().map_err(|_| DisplayError::CSError)?;
                 // 1 = data, 0 = command
                 self.dc.set_low().map_err(|_| DisplayError::DCError)?;
                 let err = self
                     .spi
-                    .write(iter.as_slice())
+                    .write(slice)
                     .map_err(|_| DisplayError::BusWriteError);
                 self.cs.set_high().ok();
                 err
@@ -53,13 +53,13 @@ where
 
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
         match buf {
-            DataFormat::U8(iter) => {
+            DataFormat::U8(slice) => {
                 self.cs.set_low().map_err(|_| DisplayError::CSError)?;
                 // 1 = data, 0 = command
                 self.dc.set_high().map_err(|_| DisplayError::DCError)?;
                 let err = self
                     .spi
-                    .write(iter.as_slice())
+                    .write(slice)
                     .map_err(|_| DisplayError::BusWriteError);
                 self.cs.set_high().ok();
                 err
@@ -95,11 +95,11 @@ where
 {
     fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
         match cmds {
-            DataFormat::U8(iter) => {
+            DataFormat::U8(slice) => {
                 // 1 = data, 0 = command
                 self.dc.set_low().map_err(|_| DisplayError::DCError)?;
                 self.spi
-                    .write(iter.as_slice())
+                    .write(slice)
                     .map_err(|_| DisplayError::BusWriteError)
             }
             _ => Err(DisplayError::BusWriteError),
@@ -108,11 +108,11 @@ where
 
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
         match buf {
-            DataFormat::U8(iter) => {
+            DataFormat::U8(slice) => {
                 // 1 = data, 0 = command
                 self.dc.set_high().map_err(|_| DisplayError::DCError)?;
                 self.spi
-                    .write(iter.as_slice())
+                    .write(slice)
                     .map_err(|_| DisplayError::BusWriteError)
             }
             _ => Err(DisplayError::BusWriteError),

--- a/spi/src/lib.rs
+++ b/spi/src/lib.rs
@@ -5,7 +5,7 @@
 use embedded_hal as hal;
 use hal::digital::v2::OutputPin;
 
-use display_interface::{DisplayError, WriteOnlyDataCommand, DataFormat};
+use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 
 /// SPI display interface.
 ///
@@ -34,7 +34,7 @@ where
     DC: OutputPin,
     CS: OutputPin,
 {
-    fn send_commands<'a>(&mut self, cmds: DataFormat<'a>) -> Result<(), DisplayError> {
+    fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
         match cmds {
             DataFormat::U8(iter) => {
                 self.cs.set_low().map_err(|_| DisplayError::CSError)?;
@@ -46,12 +46,12 @@ where
                     .map_err(|_| DisplayError::BusWriteError);
                 self.cs.set_high().ok();
                 err
-            },
-            _ => Err(DisplayError::BusWriteError)
+            }
+            _ => Err(DisplayError::BusWriteError),
         }
     }
 
-    fn send_data<'a>(&mut self, buf: DataFormat<'a>) -> Result<(), DisplayError> {
+    fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
         match buf {
             DataFormat::U8(iter) => {
                 self.cs.set_low().map_err(|_| DisplayError::CSError)?;
@@ -63,8 +63,8 @@ where
                     .map_err(|_| DisplayError::BusWriteError);
                 self.cs.set_high().ok();
                 err
-            },
-            _ => Err(DisplayError::BusWriteError)
+            }
+            _ => Err(DisplayError::BusWriteError),
         }
     }
 }
@@ -93,7 +93,7 @@ where
     SPI: hal::blocking::spi::Write<u8>,
     DC: OutputPin,
 {
-    fn send_commands<'a>(&mut self, cmds: DataFormat<'a>) -> Result<(), DisplayError> {
+    fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
         match cmds {
             DataFormat::U8(iter) => {
                 // 1 = data, 0 = command
@@ -101,12 +101,12 @@ where
                 self.spi
                     .write(iter.as_slice())
                     .map_err(|_| DisplayError::BusWriteError)
-            },
-            _ => Err(DisplayError::BusWriteError)
+            }
+            _ => Err(DisplayError::BusWriteError),
         }
     }
 
-    fn send_data<'a>(&mut self, buf: DataFormat<'a>) -> Result<(), DisplayError> {
+    fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
         match buf {
             DataFormat::U8(iter) => {
                 // 1 = data, 0 = command
@@ -114,8 +114,8 @@ where
                 self.spi
                     .write(iter.as_slice())
                     .map_err(|_| DisplayError::BusWriteError)
-            },
-            _ => Err(DisplayError::BusWriteError)
+            }
+            _ => Err(DisplayError::BusWriteError),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ pub enum DisplayError {
     CSError,
 }
 
+/// DI specific data format wrapper around slices of various widths
+/// Display drivers need to implement non-trivial conversions (e.g. with padding)
+/// as the hardware requires.
 pub enum DataFormat<'a> {
     U8(&'a [u8]),
     U16(&'a [u16]),
@@ -31,6 +34,7 @@ impl<'a> From<&'a [u8]> for DataFormat<'a> {
         Self::U8(arr_ref)
     }
 }
+
 impl<'a> From<&'a [u16]> for DataFormat<'a> {
     fn from(arr_ref: &'a [u16]) -> Self {
         Self::U16(arr_ref)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,11 @@ pub enum DisplayError {
 /// This trait implements a write-only interface for a display which has separate data and command
 /// modes. It is the responsibility of implementations to activate the correct mode in their
 /// implementation when corresponding method is called.
-pub trait WriteOnlyDataCommand<WIDTH> {
+pub trait WriteOnlyDataCommand {
+    type Width: Copy + Sized;
     /// Send a batch of commands to display
-    fn send_commands(&mut self, cmd: &[WIDTH]) -> Result<(), DisplayError>;
+    fn send_commands(&mut self, cmd: &[Self::Width]) -> Result<(), DisplayError>;
 
     /// Send pixel data to display
-    fn send_data(&mut self, buf: &[WIDTH]) -> Result<(), DisplayError>;
+    fn send_data(&mut self, buf: &[Self::Width]) -> Result<(), DisplayError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
 //! to drive a display and allows a driver writer to focus on driving the display itself and only
 //! have to implement a single interface.
 
-use core::slice::Iter as SliceIter;
-
 pub mod prelude;
 
 /// A ubiquitous error type for all kinds of problems which could happen when communicating with a
@@ -24,31 +22,18 @@ pub enum DisplayError {
 }
 
 pub enum DataFormat<'a> {
-    U8(SliceIter<'a, u8>),
-    U16(SliceIter<'a, u16>),
+    U8(&'a [u8]),
+    U16(&'a [u16]),
 }
 
 impl<'a> From<&'a [u8]> for DataFormat<'a> {
     fn from(arr_ref: &'a [u8]) -> Self {
-        Self::U8(arr_ref.into_iter())
+        Self::U8(arr_ref)
     }
 }
-
-impl<'a> From<SliceIter<'a, u8>> for DataFormat<'a> {
-    fn from(iter: SliceIter<'a, u8>) -> Self {
-        Self::U8(iter)
-    }
-}
-
-impl<'a> From<SliceIter<'a, u16>> for DataFormat<'a> {
-    fn from(iter: SliceIter<'a, u16>) -> Self {
-        Self::U16(iter)
-    }
-}
-
 impl<'a> From<&'a [u16]> for DataFormat<'a> {
     fn from(arr_ref: &'a [u16]) -> Self {
-        Self::U16(arr_ref.into_iter())
+        Self::U16(arr_ref)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ impl<'a> From<&'a [u16]> for DataFormat<'a> {
 /// implementation when corresponding method is called.
 pub trait WriteOnlyDataCommand {
     /// Send a batch of commands to display
-    fn send_commands<'a>(&mut self, cmd: DataFormat<'a>) -> Result<(), DisplayError>;
+    fn send_commands(&mut self, cmd: DataFormat<'_>) -> Result<(), DisplayError>;
 
     /// Send pixel data to display
-    fn send_data<'a>(&mut self, buf: DataFormat<'a>) -> Result<(), DisplayError>;
+    fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub mod prelude;
 /// display
 #[derive(Clone, Debug)]
 pub enum DisplayError {
+    /// Invalid transfer format selected (e.g. u16 on u8 interface)
+    InvalidFormatError,
     /// Unable to write to bus
     BusWriteError,
     /// Unable to assert or de-assert data/command switching signal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! to drive a display and allows a driver writer to focus on driving the display itself and only
 //! have to implement a single interface.
 
+use core::slice::Iter as SliceIter;
+
 pub mod prelude;
 
 /// A ubiquitous error type for all kinds of problems which could happen when communicating with a
@@ -21,14 +23,42 @@ pub enum DisplayError {
     CSError,
 }
 
+pub enum DataFormat<'a> {
+    U8(SliceIter<'a, u8>),
+    U16(SliceIter<'a, u16>),
+}
+
+impl<'a> From<&'a [u8]> for DataFormat<'a> {
+    fn from(arr_ref: &'a [u8]) -> Self {
+        Self::U8(arr_ref.into_iter())
+    }
+}
+
+impl<'a> From<SliceIter<'a, u8>> for DataFormat<'a> {
+    fn from(iter: SliceIter<'a, u8>) -> Self {
+        Self::U8(iter)
+    }
+}
+
+impl<'a> From<SliceIter<'a, u16>> for DataFormat<'a> {
+    fn from(iter: SliceIter<'a, u16>) -> Self {
+        Self::U16(iter)
+    }
+}
+
+impl<'a> From<&'a [u16]> for DataFormat<'a> {
+    fn from(arr_ref: &'a [u16]) -> Self {
+        Self::U16(arr_ref.into_iter())
+    }
+}
+
 /// This trait implements a write-only interface for a display which has separate data and command
 /// modes. It is the responsibility of implementations to activate the correct mode in their
 /// implementation when corresponding method is called.
 pub trait WriteOnlyDataCommand {
-    type Width: Copy + Sized;
     /// Send a batch of commands to display
-    fn send_commands(&mut self, cmd: &[Self::Width]) -> Result<(), DisplayError>;
+    fn send_commands<'a>(&mut self, cmd: DataFormat<'a>) -> Result<(), DisplayError>;
 
     /// Send pixel data to display
-    fn send_data(&mut self, buf: &[Self::Width]) -> Result<(), DisplayError>;
+    fn send_data<'a>(&mut self, buf: DataFormat<'a>) -> Result<(), DisplayError>;
 }


### PR DESCRIPTION
First attempted WIP for associated type usage to allow easier "any Sized + Copy" for data format.

NOTE: tested with `ST7789` and `display-interface-spi` using `u8` "hardcoded", didn't try to use `u16` anywhere yet.