### PR TITLE
Deconstructable trait

### DIFF
--- a/i2c/src/lib.rs
+++ b/i2c/src/lib.rs
@@ -3,7 +3,7 @@
 //! Generic I2C interface for display drivers
 use embedded_hal as hal;
 
-use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
+use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand, Deconstructable};
 
 /// I2C communication interface
 pub struct I2CInterface<I2C> {
@@ -24,10 +24,17 @@ where
             data_byte,
         }
     }
+}
+
+impl<I2C> Deconstructable for I2CInterface<I2C>
+where
+    I2C: hal::blocking::i2c::Write
+{
+    type Resources = I2C;
 
     /// Consume the display interface and return
     /// the underlying peripherial driver
-    pub fn release(self) -> I2C {
+    fn release(self) -> Self::Resources {
         self.i2c
     }
 }

--- a/i2c/src/lib.rs
+++ b/i2c/src/lib.rs
@@ -24,6 +24,12 @@ where
             data_byte,
         }
     }
+
+    /// Consume the display interface and return
+    /// the underlying peripherial driver
+    pub fn release(self) -> I2C {
+        self.i2c
+    }
 }
 
 impl<I2C> WriteOnlyDataCommand for I2CInterface<I2C>

--- a/parallel-gpio/src/lib.rs
+++ b/parallel-gpio/src/lib.rs
@@ -4,7 +4,7 @@
 
 use embedded_hal::digital::v2::OutputPin;
 
-pub use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
+pub use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand, Deconstructable};
 
 /// Parallel 8 Bit communication interface
 ///
@@ -73,23 +73,6 @@ where
             wr,
             last: 0,
         }
-    }
-
-    /// Consume the display interface and return
-    /// the GPIO pins used by it
-    pub fn release(self) -> (P0, P1, P2, P3, P4, P5, P6, P7, DC, WR) {
-        (
-            self.p0,
-            self.p1,
-            self.p2,
-            self.p3,
-            self.p4,
-            self.p5,
-            self.p6,
-            self.p7,
-            self.dc,
-            self.wr
-        )
     }
 
     fn set_value(self: &mut Self, value: u8) -> Result<(), DisplayError> {
@@ -176,6 +159,40 @@ where
         };
 
         Ok(())
+    }
+}
+
+impl<P0, P1, P2, P3, P4, P5, P6, P7, DC, WR> Deconstructable
+    for PGPIO8BitInterface<P0, P1, P2, P3, P4, P5, P6, P7, DC, WR>
+where
+    P0: OutputPin,
+    P1: OutputPin,
+    P2: OutputPin,
+    P3: OutputPin,
+    P4: OutputPin,
+    P5: OutputPin,
+    P6: OutputPin,
+    P7: OutputPin,
+    DC: OutputPin,
+    WR: OutputPin
+{
+    type Resources = (P0, P1, P2, P3, P4, P5, P6, P7, DC, WR);
+
+    /// Consume the display interface and return
+    /// the GPIO pins used by it
+    fn release(self) -> Self::Resources {
+        (
+            self.p0,
+            self.p1,
+            self.p2,
+            self.p3,
+            self.p4,
+            self.p5,
+            self.p6,
+            self.p7,
+            self.dc,
+            self.wr
+        )
     }
 }
 

--- a/parallel-gpio/src/lib.rs
+++ b/parallel-gpio/src/lib.rs
@@ -75,6 +75,23 @@ where
         }
     }
 
+    /// Consume the display interface and return
+    /// the GPIO pins used by it
+    pub fn release(self) -> (P0, P1, P2, P3, P4, P5, P6, P7, DC, WR) {
+        (
+            self.p0,
+            self.p1,
+            self.p2,
+            self.p3,
+            self.p4,
+            self.p5,
+            self.p6,
+            self.p7,
+            self.dc,
+            self.wr
+        )
+    }
+
     fn set_value(self: &mut Self, value: u8) -> Result<(), DisplayError> {
         let changed = value ^ self.last;
 

--- a/spi/src/lib.rs
+++ b/spi/src/lib.rs
@@ -5,7 +5,7 @@
 use embedded_hal as hal;
 use hal::digital::v2::OutputPin;
 
-use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
+use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand, Deconstructable};
 
 fn send_u8<SPI: hal::blocking::spi::Write<u8>>(
     spi: &mut SPI,
@@ -40,10 +40,19 @@ where
     pub fn new(spi: SPI, dc: DC, cs: CS) -> Self {
         Self { spi, dc, cs }
     }
+}
+
+impl<SPI, DC, CS> Deconstructable for SPIInterface<SPI, DC, CS>
+where
+    SPI: hal::blocking::spi::Write<u8>,
+    DC: OutputPin,
+    CS: OutputPin,
+{
+    type Resources = (SPI, DC, CS);
 
     /// Consume the display interface and return
     /// the underlying peripherial driver and GPIO pins used by it
-    pub fn release(self) -> (SPI, DC, CS) {
+    fn release(self) -> Self::Resources {
         (self.spi, self.dc, self.cs)
     }
 }
@@ -104,10 +113,18 @@ where
     pub fn new(spi: SPI, dc: DC) -> Self {
         Self { spi, dc }
     }
+}
+
+impl<SPI, DC> Deconstructable for SPIInterfaceNoCS<SPI, DC>
+where
+    SPI: hal::blocking::spi::Write<u8>,
+    DC: OutputPin,
+{
+    type Resources = (SPI, DC);
 
     /// Consume the display interface and return
     /// the underlying peripherial driver and GPIO pins used by it
-    pub fn release(self) -> (SPI, DC) {
+    fn release(self) -> Self::Resources {
         (self.spi, self.dc)
     }
 }

--- a/spi/src/lib.rs
+++ b/spi/src/lib.rs
@@ -40,6 +40,12 @@ where
     pub fn new(spi: SPI, dc: DC, cs: CS) -> Self {
         Self { spi, dc, cs }
     }
+
+    /// Consume the display interface and return
+    /// the underlying peripherial driver and GPIO pins used by it
+    pub fn release(self) -> (SPI, DC, CS) {
+        (self.spi, self.dc, self.cs)
+    }
 }
 
 impl<SPI, DC, CS> WriteOnlyDataCommand for SPIInterface<SPI, DC, CS>
@@ -97,6 +103,12 @@ where
     /// Create new SPI interface for communciation with a display driver
     pub fn new(spi: SPI, dc: DC) -> Self {
         Self { spi, dc }
+    }
+
+    /// Consume the display interface and return
+    /// the underlying peripherial driver and GPIO pins used by it
+    pub fn release(self) -> (SPI, DC) {
+        (self.spi, self.dc)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,3 +53,10 @@ pub trait WriteOnlyDataCommand {
     /// Send pixel data to display
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError>;
 }
+
+/// Common trait that should be implemented by display interfaces.
+pub trait Deconstructable {
+    type Resources;
+
+    fn release(self) -> Self::Resources;
+}


### PR DESCRIPTION
This is an example implementation of how the destructors could be turned into a trait, as mentioned in #4 

While possible, I'm not sure if this is useful, or has any added benefits on top of #5
Any feedback is appreciated.