### PR TITLE
Add a ReadWriteInterface for displays.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub enum DisplayError {
     InvalidFormatError,
     /// Unable to write to bus
     BusWriteError,
+    // Unable to read from bus
+    BusReadError,
     /// Unable to assert or de-assert data/command switching signal
     DCError,
     /// Unable to assert chip select signal
@@ -56,4 +58,75 @@ pub trait WriteOnlyDataCommand {
 
     /// Send pixel data to display
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError>;
+}
+
+#[derive(Clone, Debug)]
+pub enum WriteMode {
+    Data,
+    Command,
+}
+
+pub trait ReadWriteInterface<DataFormat> {
+    fn write(&mut self, mode: WriteMode, buf: &[DataFormat]) -> Result<(), DisplayError> {
+        self.write_iter(mode, &mut buf.into_iter())
+    }
+
+    fn read(&mut self, buf: &mut [DataFormat]) -> Result<(), DisplayError> {
+        let mut n = 0;
+        self.read_stream(&mut |b| {
+            if n == buf.len() {
+                return false;
+            }
+            buf[n] = b;
+            n += 1;
+            true
+        })
+    }
+
+    fn read_stream(&mut self, f: &mut dyn FnMut(DataFormat) -> bool) -> Result<(), DisplayError>;
+
+    fn write_iter(
+        &mut self,
+        mode: WriteMode,
+        iter: &mut dyn Iterator<Item = &DataFormat>,
+    ) -> Result<(), DisplayError>;
+}
+
+pub struct ReadIterator<'a, DataFormat> {
+    rw: &'a mut dyn ReadWriteInterface<DataFormat>,
+}
+
+impl<'a, DataFormat> ReadIterator<'a, DataFormat> {
+    fn new(rw: &'a mut dyn ReadWriteInterface<DataFormat>) -> ReadIterator<'a, DataFormat> {
+        ReadIterator { rw: rw }
+    }
+}
+
+impl<'a, DataFormat> Iterator for ReadIterator<'a, DataFormat>
+where
+    DataFormat: Default,
+{
+    type Item = Result<DataFormat, DisplayError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut next: DataFormat = Default::default();
+        match self.rw.read_stream(&mut |b| {
+            next = b;
+            false
+        }) {
+            Ok(_) => Some(Ok(next)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+impl<'a, DataFormat> IntoIterator for &'a mut dyn ReadWriteInterface<DataFormat>
+where
+    DataFormat: Default,
+{
+    type Item = Result<DataFormat, DisplayError>;
+    type IntoIter = ReadIterator<'a, DataFormat>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ReadIterator::new(self)
+    }
 }


### PR DESCRIPTION
This change adds a `ReadWriteInterface` for displays that have both read/write capabilities. The interface is actually much different than the current one, so let me know what you think. This has been implemented in an ILI9486 driver I'm working on here: https://github.com/chrismoos/ili9486-driver/blob/master/src/gpio/gpio8.rs

Highlights for the change are:

* The `DataFormat` moves from an enum (useable at runtime), to the implementations. In practice, when you wire up an implementation, from compile time, you'll have a fixed mode (GPIO8/16, SPI, etc,.) so this means implementors can focus on the actual formats they support, rather than runtime handling of the enum.
* Read support via `read_stream` - this allows for efficient transfer (allowing chip to stay selected), invoking a closure until the caller is done reading, which it signals to the interface with a `bool` return in the closure.
* Write support via `write_iter` - similar to `read_stream`, this supports efficient transfer (pipelining) of a stream of bytes to the device.
* An `Iterator` is provided automatically for `ReadWriteInterface`, allowing you to easily iterate over the interface to read bytes.
* Implementors of `ReadWriteInterface` must only implement the above 2 methods, the trait provides some default "helper" methods to read into a fixed buffer, or write from a fixed buffer.

PS @therealprof I saw SSD1306 does have read support, also, so not sure which ones would be "write only". Regardless, this could be combined (the RW) into a super trait if you think that makes the most sense.