### PR TITLE
Simplify parallel GPIO interface and add new error variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-interface"
 description = "Traits for interfaces used to drive displays"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
 repository = "https://github.com/therealprof/display-interface"
 documentation = "https://docs.rs/display-interface"

--- a/parallel-gpio/Cargo.toml
+++ b/parallel-gpio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display-interface-parallel-gpio"
 description = "Generic parallel GPIO interface for display interfaces"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Daniel Egger <daniel@eggers-club.de>"]
 repository = "https://github.com/therealprof/display-interface"
 documentation = "https://docs.rs/display-interface-parallel-gpio"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub enum DisplayError {
     CSError,
     /// The requested DataFormat is not implemented by this display interface implementation
     DataFormatNotImplemented,
+    /// Unable to assert or de-assert reset signal
+    RSError,
 }
 
 /// DI specific data format wrapper around slices of various widths


### PR DESCRIPTION
I simplified the API for the parallel GPIO interface by grouping the bus into an array of pins rather than 8 individual pins. This allows to further simplify the `set_value()` function.

I also added a new variant to the `DisplayError` enum to represent issues that arise while asserting or de-asserting the reset pin. That is not used in these crates, but it is a useful error to have for consumers of this library.