### PR TITLE
Add new RSError variant to DisplayError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New `DisplayError` variant `RSError` to use with problems with the display's reset signal
+
 ## [v0.4.0] - 2020-05-25
 
 ### Added
 
 - Support for 8bit and 16bit iterators as data format
 - Support for 16bit slice data format with target endian
-- Deconstructurs for included display-interface implementations
+- Deconstructors for included display-interface implementations
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub enum DisplayError {
     CSError,
     /// The requested DataFormat is not implemented by this display interface implementation
     DataFormatNotImplemented,
+    /// Unable to assert or de-assert reset signal
+    RSError,
 }
 
 /// DI specific data format wrapper around slices of various widths


### PR DESCRIPTION
Useful if the user of the crate wants to implement a `fn reset() -> Result<(),  DisplayError>` function