### PR TITLE
Return DCError instead of BusWriteError on DC signal assertion errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Return `DCError` instead of `BusWriteError` on errors (de-)asserting the DC signal in 8-bit GPIO interfaces
+
 ## [v0.4.0] - 2020-05-25
 
 ### Added

--- a/parallel-gpio/src/lib.rs
+++ b/parallel-gpio/src/lib.rs
@@ -187,7 +187,7 @@ where
 {
     fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
         use byte_slice_cast::*;
-        self.dc.set_low().map_err(|_| DisplayError::BusWriteError)?;
+        self.dc.set_low().map_err(|_| DisplayError::DCError)?;
         match cmds {
             DataFormat::U8(slice) => slice.iter().try_for_each(|cmd| {
                 self.wr.set_low().map_err(|_| DisplayError::BusWriteError)?;
@@ -240,7 +240,7 @@ where
         use byte_slice_cast::*;
         self.dc
             .set_high()
-            .map_err(|_| DisplayError::BusWriteError)?;
+            .map_err(|_| DisplayError::DCError)?;
         match buf {
             DataFormat::U8(slice) => slice.iter().try_for_each(|d| {
                 self.wr.set_low().map_err(|_| DisplayError::BusWriteError)?;

--- a/parallel-gpio/src/lib.rs
+++ b/parallel-gpio/src/lib.rs
@@ -238,9 +238,7 @@ where
 
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
         use byte_slice_cast::*;
-        self.dc
-            .set_high()
-            .map_err(|_| DisplayError::DCError)?;
+        self.dc.set_high().map_err(|_| DisplayError::DCError)?;
         match buf {
             DataFormat::U8(slice) => slice.iter().try_for_each(|d| {
                 self.wr.set_low().map_err(|_| DisplayError::BusWriteError)?;


### PR DESCRIPTION
I think `DCError` should be returned instead of `BusWriteError`.