### PR TITLE
Simplify 8-bit display interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- display-interface-parallel-gpio API now takes an array of `OutputPin` for the parallel data bus rather than 8 separate `OutputPin`
+
 ## [v0.4.0] - 2020-05-25
 
 ### Added

--- a/parallel-gpio/src/lib.rs
+++ b/parallel-gpio/src/lib.rs
@@ -18,57 +18,23 @@ pub use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 /// All pins are supposed to be high-active, high for the D/C pin meaning "data" and the
 /// write-enable being pulled low before the setting of the bits and supposed to be sampled at a
 /// low to high edge.
-pub struct PGPIO8BitInterface<P0, P1, P2, P3, P4, P5, P6, P7, DC, WR> {
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
+pub struct PGPIO8BitInterface<DBUS, DC, WR> {
+    dbus: [DBUS; 8],
     dc: DC,
     wr: WR,
     last: u8,
 }
 
-impl<P0, P1, P2, P3, P4, P5, P6, P7, DC, WR>
-    PGPIO8BitInterface<P0, P1, P2, P3, P4, P5, P6, P7, DC, WR>
+impl<DBUS, DC, WR> PGPIO8BitInterface<DBUS, DC, WR>
 where
-    P0: OutputPin,
-    P1: OutputPin,
-    P2: OutputPin,
-    P3: OutputPin,
-    P4: OutputPin,
-    P5: OutputPin,
-    P6: OutputPin,
-    P7: OutputPin,
+    DBUS: OutputPin,
     DC: OutputPin,
     WR: OutputPin,
 {
     /// Create new parallel GPIO interface for communication with a display driver
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        p0: P0,
-        p1: P1,
-        p2: P2,
-        p3: P3,
-        p4: P4,
-        p5: P5,
-        p6: P6,
-        p7: P7,
-        dc: DC,
-        wr: WR,
-    ) -> Self {
+    pub fn new(dbus: [DBUS; 8], dc: DC, wr: WR) -> Self {
         Self {
-            p0,
-            p1,
-            p2,
-            p3,
-            p4,
-            p5,
-            p6,
-            p7,
+            dbus,
             dc,
             wr,
             last: 0,
@@ -77,11 +43,8 @@ where
 
     /// Consume the display interface and return
     /// the GPIO pins used by it
-    pub fn release(self) -> (P0, P1, P2, P3, P4, P5, P6, P7, DC, WR) {
-        (
-            self.p0, self.p1, self.p2, self.p3, self.p4, self.p5, self.p6, self.p7, self.dc,
-            self.wr,
-        )
+    pub fn release(self) -> ([DBUS; 8], DC, WR) {
+        (self.dbus, self.dc, self.wr)
     }
 
     fn set_value(self: &mut Self, value: u8) -> Result<(), DisplayError> {
@@ -95,93 +58,24 @@ where
 
         self.last = value;
 
-        if changed & 1 != 0 {
-            if value & 1 != 0 {
-                self.p0.set_high()
-            } else {
-                self.p0.set_low()
+        for i in 0..8 {
+            if changed & (1 << i) != 0 {
+                if value & (1 << i) == 0 {
+                    self.dbus[i].set_low()
+                } else {
+                    self.dbus[i].set_high()
+                }
+                .map_err(|_| DisplayError::BusWriteError)?;
             }
-            .map_err(|_| DisplayError::BusWriteError)?
-        };
-
-        if changed & 2 != 0 {
-            if value & 2 != 0 {
-                self.p1.set_high()
-            } else {
-                self.p1.set_low()
-            }
-            .map_err(|_| DisplayError::BusWriteError)?
-        };
-
-        if changed & 4 != 0 {
-            if value & 4 != 0 {
-                self.p2.set_high()
-            } else {
-                self.p2.set_low()
-            }
-            .map_err(|_| DisplayError::BusWriteError)?
-        };
-
-        if changed & 8 != 0 {
-            if value & 8 != 0 {
-                self.p3.set_high()
-            } else {
-                self.p3.set_low()
-            }
-            .map_err(|_| DisplayError::BusWriteError)?
-        };
-
-        if changed & 16 != 0 {
-            if value & 16 != 0 {
-                self.p4.set_high()
-            } else {
-                self.p4.set_low()
-            }
-            .map_err(|_| DisplayError::BusWriteError)?
-        };
-
-        if changed & 32 != 0 {
-            if value & 32 != 0 {
-                self.p5.set_high()
-            } else {
-                self.p5.set_low()
-            }
-            .map_err(|_| DisplayError::BusWriteError)?
-        };
-
-        if changed & 64 != 0 {
-            if value & 64 != 0 {
-                self.p6.set_high()
-            } else {
-                self.p6.set_low()
-            }
-            .map_err(|_| DisplayError::BusWriteError)?
-        };
-
-        if changed & 128 != 0 {
-            if value & 128 != 0 {
-                self.p7.set_high()
-            } else {
-                self.p7.set_low()
-            }
-            .map_err(|_| DisplayError::BusWriteError)?
-        };
+        }
 
         Ok(())
     }
 }
 
-impl<P0, P1, P2, P3, P4, P5, P6, P7, DC, WR> WriteOnlyDataCommand
-    for PGPIO8BitInterface<P0, P1, P2, P3, P4, P5, P6, P7, DC, WR>
+impl<DBUS, DC, WR> WriteOnlyDataCommand for PGPIO8BitInterface<DBUS, DC, WR>
 where
-    P0: OutputPin,
-    P1: OutputPin,
-    P2: OutputPin,
-    P3: OutputPin,
-    P4: OutputPin,
-    P5: OutputPin,
-    P6: OutputPin,
-    P7: OutputPin,
+    DBUS: OutputPin,
     DC: OutputPin,
     WR: OutputPin,
 {


### PR DESCRIPTION
I simplified the API for the parallel GPIO interface by grouping the bus into an array of pins rather than 8 individual pins. This allows to further simplify the `set_value()` function.