### PR TITLE
Add borrowed SPI bus interfaces

### DIFF
--- a/spi/Cargo.toml
+++ b/spi/Cargo.toml
@@ -18,6 +18,6 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.9"
 display-interface = "0.4.1"
 byte-slice-cast = { version = "0.3.5", default-features = false }

--- a/spi/Cargo.toml
+++ b/spi/Cargo.toml
@@ -18,6 +18,6 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-embedded-hal = "1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.8"
 display-interface = "0.4.1"
 byte-slice-cast = { version = "0.3.5", default-features = false }

--- a/spi/src/lib.rs
+++ b/spi/src/lib.rs
@@ -3,8 +3,8 @@
 //! Generic SPI interface for display drivers
 
 use embedded_hal::{
-    digital::blocking::OutputPin,
-    spi::blocking::{SpiBusWrite, SpiDevice},
+    digital::OutputPin,
+    spi::{SpiBusWrite, SpiDevice},
 };
 
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};


### PR DESCRIPTION
## Motivation

In many cases, the SPI bus is not just connected to a single device. So taking full ownership isn't always practical.

It's a lot easier to have the SPI bus managed by a different management struct, and then create a temporary display interface on demand. That way sharing an SPI bus is trivially possible:

```rust
let mut spi_manager = SPIManager::new(spi_bus, ...pins...);
let display_bus: SPIInterface = spi_manager.get_display_bus();
do_display_things(display_bus);
// Drop display_bus to re-use SPI for other things
```
Sadly, this doesn't work with the current API of this crate, as the bus always takes full ownership.

## Solution

- Add the structs `BorrowedSPIBus` and `BorrowedSPIBusNoCS` that only borrow their peripherals.
- Refactor `SPIBus` and `SPIBusNoCS` to avoid code duplication


