### PR TITLE
Propose to use CamelCase for SpiInterface structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New `AsyncWriteOnlyDataCommand` trait.
 - i2c, spi: `async/await` support.
 - parallel-gpio: Added `Generic16BitBus`
-- parallel-gpio: Added `PGPIO16BitInterface`
+- parallel-gpio: Added `PGpio16BitInterface`
 - added `defmt-03` feature
 
 ## Changed
 
 - **Breaking** raised MSRV to 1.75
-- spi: `SPIInterface` now wraps objects that implement the `SpiDeviceWrite` trait from embedded-hal 1.0.0
-- spi: `SPIInterface` now wraps objects that implement the `SpiDeviceWrite` trait from embedded-hal-async 1.0.0
+- spi: `SpiInterface` now wraps objects that implement the `SpiDeviceWrite` trait from embedded-hal 1.0.0
+- spi: `SpiInterface` now wraps objects that implement the `SpiDeviceWrite` trait from embedded-hal-async 1.0.0
 - parallel-gpio: Fixed bug with fallible pins
 - **Breaking** parallel-gpio: `GenericxBitBus::new` is now infallible
+- **Breaking** lib: `{SPI, I2C}Interface, PGPIO{8, 16}BitInterface` is renamed to `{Spi, I2c}Interface, PGpio{8, 16}BitInterface`
 
 ## [v0.4.1] - 2021-05-10
 

--- a/i2c/src/asynch.rs
+++ b/i2c/src/asynch.rs
@@ -1,8 +1,8 @@
 use display_interface::{AsyncWriteOnlyDataCommand, DataFormat, DisplayError};
 
-use crate::I2CInterface;
+use crate::I2cInterface;
 
-impl<I2C> AsyncWriteOnlyDataCommand for I2CInterface<I2C>
+impl<I2C> AsyncWriteOnlyDataCommand for I2cInterface<I2C>
 where
     I2C: embedded_hal_async::i2c::I2c,
 {

--- a/i2c/src/lib.rs
+++ b/i2c/src/lib.rs
@@ -7,13 +7,13 @@ mod asynch;
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 
 /// I2C communication interface
-pub struct I2CInterface<I2C> {
+pub struct I2cInterface<I2C> {
     i2c: I2C,
     addr: u8,
     data_byte: u8,
 }
 
-impl<I2C> I2CInterface<I2C> {
+impl<I2C> I2cInterface<I2C> {
     /// Create new I2C interface for communication with a display driver
     pub fn new(i2c: I2C, addr: u8, data_byte: u8) -> Self {
         Self {
@@ -30,7 +30,7 @@ impl<I2C> I2CInterface<I2C> {
     }
 }
 
-impl<I2C> WriteOnlyDataCommand for I2CInterface<I2C>
+impl<I2C> WriteOnlyDataCommand for I2cInterface<I2C>
 where
     I2C: embedded_hal::i2c::I2c,
 {

--- a/parallel-gpio/src/lib.rs
+++ b/parallel-gpio/src/lib.rs
@@ -143,13 +143,13 @@ generic_bus! {
 /// All pins are supposed to be high-active, high for the D/C pin meaning "data" and the
 /// write-enable being pulled low before the setting of the bits and supposed to be sampled at a
 /// low to high edge.
-pub struct PGPIO8BitInterface<BUS, DC, WR> {
+pub struct PGpio8BitInterface<BUS, DC, WR> {
     bus: BUS,
     dc: DC,
     wr: WR,
 }
 
-impl<BUS, DC, WR> PGPIO8BitInterface<BUS, DC, WR>
+impl<BUS, DC, WR> PGpio8BitInterface<BUS, DC, WR>
 where
     BUS: OutputBus<Word = u8>,
     DC: OutputPin,
@@ -201,7 +201,7 @@ where
     }
 }
 
-impl<BUS, DC, WR> WriteOnlyDataCommand for PGPIO8BitInterface<BUS, DC, WR>
+impl<BUS, DC, WR> WriteOnlyDataCommand for PGpio8BitInterface<BUS, DC, WR>
 where
     BUS: OutputBus<Word = u8>,
     DC: OutputPin,
@@ -227,13 +227,13 @@ where
 /// All pins are supposed to be high-active, high for the D/C pin meaning "data" and the
 /// write-enable being pulled low before the setting of the bits and supposed to be sampled at a
 /// low to high edge.
-pub struct PGPIO16BitInterface<BUS, DC, WR> {
+pub struct PGpio16BitInterface<BUS, DC, WR> {
     bus: BUS,
     dc: DC,
     wr: WR,
 }
 
-impl<BUS, DC, WR> PGPIO16BitInterface<BUS, DC, WR>
+impl<BUS, DC, WR> PGpio16BitInterface<BUS, DC, WR>
 where
     BUS: OutputBus<Word = u16>,
     DC: OutputPin,
@@ -276,7 +276,7 @@ where
     }
 }
 
-impl<BUS, DC, WR> WriteOnlyDataCommand for PGPIO16BitInterface<BUS, DC, WR>
+impl<BUS, DC, WR> WriteOnlyDataCommand for PGpio16BitInterface<BUS, DC, WR>
 where
     BUS: OutputBus<Word = u16>,
     DC: OutputPin,

--- a/spi/src/asynch.rs
+++ b/spi/src/asynch.rs
@@ -6,7 +6,7 @@ use embedded_hal_async::spi::SpiDevice;
 
 use display_interface::{AsyncWriteOnlyDataCommand, DataFormat, DisplayError};
 
-use crate::{SPIInterface, BUFFER_SIZE};
+use crate::{SpiInterface, BUFFER_SIZE};
 
 type Result = core::result::Result<(), DisplayError>;
 
@@ -116,7 +116,7 @@ where
     }
 }
 
-impl<SPI, DC> AsyncWriteOnlyDataCommand for SPIInterface<SPI, DC>
+impl<SPI, DC> AsyncWriteOnlyDataCommand for SpiInterface<SPI, DC>
 where
     SPI: SpiDevice,
     DC: OutputPin,

--- a/spi/src/lib.rs
+++ b/spi/src/lib.rs
@@ -108,12 +108,12 @@ where
 /// SPI display interface.
 ///
 /// This combines the SPI peripheral and a data/command pin
-pub struct SPIInterface<SPI, DC> {
+pub struct SpiInterface<SPI, DC> {
     spi: SPI,
     dc: DC,
 }
 
-impl<SPI, DC> SPIInterface<SPI, DC> {
+impl<SPI, DC> SpiInterface<SPI, DC> {
     /// Create new SPI interface for communication with a display driver
     pub fn new(spi: SPI, dc: DC) -> Self {
         Self { spi, dc }
@@ -126,7 +126,7 @@ impl<SPI, DC> SPIInterface<SPI, DC> {
     }
 }
 
-impl<SPI, DC> WriteOnlyDataCommand for SPIInterface<SPI, DC>
+impl<SPI, DC> WriteOnlyDataCommand for SpiInterface<SPI, DC>
 where
     SPI: SpiDevice,
     DC: OutputPin,


### PR DESCRIPTION
I'd like to propose that we name the SPI interface structure `SpiInterface` other than `SPIInterface`, for that:

- in `embedded-hal`, `Spi` in `SpiDevice` and `SpiBus` are spelled in CamelCase, we can follow this convention to be consistent,
- in [rust-lang Rust API guideline](https://rust-lang.github.io/api-guidelines/naming.html), it suggest that types are named in UpperCamelCase, with following descriptions:

> In UpperCamelCase, acronyms and contractions of compound words count as one word: use Uuid rather than UUID, Usize rather than USize or Stdin rather than StdIn. In snake_case, acronyms and contractions are lower-cased: is_xid_start.

... in this case, SPI can be treated as an acronym, it counts as one word, so only the first 'S' should be upper cased.

r? @bugadani