### PR TITLE
lib: add #[inline] hint for most of the functions

### DIFF
--- a/i2c/src/asynch.rs
+++ b/i2c/src/asynch.rs
@@ -6,6 +6,7 @@ impl<I2C> AsyncWriteOnlyDataCommand for I2cInterface<I2C>
 where
     I2C: embedded_hal_async::i2c::I2c,
 {
+    #[inline]
     async fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
         // Copy over given commands to new aray to prefix with command identifier
         match cmds {
@@ -22,6 +23,7 @@ where
         }
     }
 
+    #[inline]
     async fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
         match buf {
             DataFormat::U8(slice) => {

--- a/i2c/src/lib.rs
+++ b/i2c/src/lib.rs
@@ -15,6 +15,7 @@ pub struct I2cInterface<I2C> {
 
 impl<I2C> I2cInterface<I2C> {
     /// Create new I2C interface for communication with a display driver
+    #[inline]
     pub fn new(i2c: I2C, addr: u8, data_byte: u8) -> Self {
         Self {
             i2c,
@@ -25,6 +26,7 @@ impl<I2C> I2cInterface<I2C> {
 
     /// Consume the display interface and return
     /// the underlying peripheral driver
+    #[inline]
     pub fn release(self) -> I2C {
         self.i2c
     }
@@ -34,6 +36,7 @@ impl<I2C> WriteOnlyDataCommand for I2cInterface<I2C>
 where
     I2C: embedded_hal::i2c::I2c,
 {
+    #[inline]
     fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result<(), DisplayError> {
         // Copy over given commands to new aray to prefix with command identifier
         match cmds {
@@ -49,6 +52,7 @@ where
         }
     }
 
+    #[inline]
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
         match buf {
             DataFormat::U8(slice) => {

--- a/parallel-gpio/src/lib.rs
+++ b/parallel-gpio/src/lib.rs
@@ -32,11 +32,13 @@ macro_rules! generic_bus {
             /// Creates a new bus. This does not change the state of the pins.
             ///
             /// The first pin in the tuple is the least significant bit.
+            #[inline]
             pub fn new(pins: ($($PX, )*)) -> Self {
                 Self { pins, last: None }
             }
 
             /// Consumes the bus and returns the pins. This does not change the state of the pins.
+            #[inline]
             pub fn release(self) -> ($($PX, )*) {
                 self.pins
             }
@@ -49,6 +51,7 @@ macro_rules! generic_bus {
         {
             type Word = $Word;
 
+            #[inline]
             fn set_value(&mut self, value: Self::Word) -> Result {
                 if self.last == Some(value) {
                     // It's quite common for multiple consecutive values to be identical, e.g. when filling or
@@ -87,6 +90,7 @@ macro_rules! generic_bus {
         where
             $($PX: OutputPin, )*
         {
+            #[inline]
             fn from(pins: ($($PX, )*)) -> Self {
                 Self::new(pins)
             }
@@ -156,16 +160,19 @@ where
     WR: OutputPin,
 {
     /// Create new parallel GPIO interface for communication with a display driver
+    #[inline]
     pub fn new(bus: BUS, dc: DC, wr: WR) -> Self {
         Self { bus, dc, wr }
     }
 
     /// Consume the display interface and return
     /// the bus and GPIO pins used by it
+    #[inline]
     pub fn release(self) -> (BUS, DC, WR) {
         (self.bus, self.dc, self.wr)
     }
 
+    #[inline]
     fn write_iter(&mut self, iter: impl Iterator<Item = u8>) -> Result {
         for value in iter {
             self.wr.set_low().map_err(|_| DisplayError::BusWriteError)?;
@@ -178,11 +185,13 @@ where
         Ok(())
     }
 
+    #[inline]
     fn write_pairs(&mut self, iter: impl Iterator<Item = [u8; 2]>) -> Result {
         use core::iter::once;
         self.write_iter(iter.flat_map(|[first, second]| once(first).chain(once(second))))
     }
 
+    #[inline]
     fn write_data(&mut self, data: DataFormat<'_>) -> Result {
         match data {
             DataFormat::U8(slice) => self.write_iter(slice.iter().copied()),
@@ -207,11 +216,13 @@ where
     DC: OutputPin,
     WR: OutputPin,
 {
+    #[inline]
     fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result {
         self.dc.set_low().map_err(|_| DisplayError::DCError)?;
         self.write_data(cmds)
     }
 
+    #[inline]
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result {
         self.dc.set_high().map_err(|_| DisplayError::DCError)?;
         self.write_data(buf)
@@ -240,16 +251,19 @@ where
     WR: OutputPin,
 {
     /// Create new parallel GPIO interface for communication with a display driver
+    #[inline]
     pub fn new(bus: BUS, dc: DC, wr: WR) -> Self {
         Self { bus, dc, wr }
     }
 
     /// Consume the display interface and return
     /// the bus and GPIO pins used by it
+    #[inline]
     pub fn release(self) -> (BUS, DC, WR) {
         (self.bus, self.dc, self.wr)
     }
 
+    #[inline]
     fn write_iter(&mut self, iter: impl Iterator<Item = u16>) -> Result {
         for value in iter {
             self.wr.set_low().map_err(|_| DisplayError::BusWriteError)?;
@@ -262,6 +276,7 @@ where
         Ok(())
     }
 
+    #[inline]
     fn write_data(&mut self, data: DataFormat<'_>) -> Result {
         match data {
             DataFormat::U8(slice) => self.write_iter(slice.iter().copied().map(u16::from)),
@@ -282,11 +297,13 @@ where
     DC: OutputPin,
     WR: OutputPin,
 {
+    #[inline]
     fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result {
         self.dc.set_low().map_err(|_| DisplayError::DCError)?;
         self.write_data(cmds)
     }
 
+    #[inline]
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result {
         self.dc.set_high().map_err(|_| DisplayError::DCError)?;
         self.write_data(buf)

--- a/spi/src/asynch.rs
+++ b/spi/src/asynch.rs
@@ -10,6 +10,7 @@ use crate::{SpiInterface, BUFFER_SIZE};
 
 type Result = core::result::Result<(), DisplayError>;
 
+#[inline]
 async fn send_u8<SPI>(spi: &mut SPI, words: DataFormat<'_>) -> Result
 where
     SPI: SpiDevice,
@@ -121,6 +122,7 @@ where
     SPI: SpiDevice,
     DC: OutputPin,
 {
+    #[inline]
     async fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result {
         // 1 = data, 0 = command
         self.dc.set_low().map_err(|_| DisplayError::DCError)?;
@@ -129,6 +131,7 @@ where
         send_u8(&mut self.spi, cmds).await
     }
 
+    #[inline]
     async fn send_data(&mut self, buf: DataFormat<'_>) -> Result {
         // 1 = data, 0 = command
         self.dc.set_high().map_err(|_| DisplayError::DCError)?;

--- a/spi/src/lib.rs
+++ b/spi/src/lib.rs
@@ -12,6 +12,7 @@ type Result = core::result::Result<(), DisplayError>;
 
 pub(crate) const BUFFER_SIZE: usize = 64;
 
+#[inline]
 fn send_u8<SPI>(spi: &mut SPI, words: DataFormat<'_>) -> Result
 where
     SPI: SpiDevice,
@@ -115,12 +116,14 @@ pub struct SpiInterface<SPI, DC> {
 
 impl<SPI, DC> SpiInterface<SPI, DC> {
     /// Create new SPI interface for communication with a display driver
+    #[inline]
     pub fn new(spi: SPI, dc: DC) -> Self {
         Self { spi, dc }
     }
 
     /// Consume the display interface and return
     /// the underlying peripheral driver and GPIO pins used by it
+    #[inline]
     pub fn release(self) -> (SPI, DC) {
         (self.spi, self.dc)
     }
@@ -131,6 +134,7 @@ where
     SPI: SpiDevice,
     DC: OutputPin,
 {
+    #[inline]
     fn send_commands(&mut self, cmds: DataFormat<'_>) -> Result {
         // 1 = data, 0 = command
         self.dc.set_low().map_err(|_| DisplayError::DCError)?;
@@ -139,6 +143,7 @@ where
         send_u8(&mut self.spi, cmds)
     }
 
+    #[inline]
     fn send_data(&mut self, buf: DataFormat<'_>) -> Result {
         // 1 = data, 0 = command
         self.dc.set_high().map_err(|_| DisplayError::DCError)?;


### PR DESCRIPTION
This pull request adds #[inline] to most of the functions; it will perform better on bare-metal programs.