### PR TITLE
Add a derive(PartialEq, Eq) to DisplayError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod prelude;
 
 /// A ubiquitous error type for all kinds of problems which could happen when communicating with a
 /// display
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum DisplayError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod prelude;
 
 /// A ubiquitous error type for all kinds of problems which could happen when communicating with a
 /// display
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Copy)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum DisplayError {


### PR DESCRIPTION
In my own project I'm making an enum that contains various error types, and one of those is a display error from the `ssd1306` crate, but when I tried deriving PartialEq and Eq on my enum, I found myself unable to because it contained your enum `DisplayError` as a parameter, and that doesn't implement it.

So, I'm doing this to help myself, really.

Feel free to bump up the release number before merge, but I would love if this got merged soon so that I can nag `ssd1306`'s maintainer to update next.